### PR TITLE
fix: 纠正 merge-sort 页面「归并排序」维基百科词条链接标题

### DIFF
--- a/docs/basic/merge-sort.md
+++ b/docs/basic/merge-sort.md
@@ -115,5 +115,5 @@ def merge_sort(ll, rr):
 ## 外部链接
 
 - [Merge Sort - GeeksforGeeks](https://www.geeksforgeeks.org/merge-sort/)
-- [希尔排序 - 维基百科，自由的百科全书](https://zh.wikipedia.org/wiki/%E5%BD%92%E5%B9%B6%E6%8E%92%E5%BA%8F)
+- [归并排序 - 维基百科，自由的百科全书](https://zh.wikipedia.org/wiki/%E5%BD%92%E5%B9%B6%E6%8E%92%E5%BA%8F)
 - [逆序对 - 维基百科，自由的百科全书](https://zh.wikipedia.org/wiki/%E9%80%86%E5%BA%8F%E5%AF%B9)


### PR DESCRIPTION
链接实际上指向维基百科的「归并排序」词条，本文章主题也是「归并排序」。